### PR TITLE
Revert "beast ssl: do not raise exception if stream is truncated (hornet)"

### DIFF
--- a/cppclient/beast.cc
+++ b/cppclient/beast.cc
@@ -127,10 +127,7 @@ nonstd::optional<json> BeastIotaAPI::postSsl(const json& input) {
 
     stream.shutdown(ec);
 
-    if (ec && ec != boost::system::errc::not_connected &&
-            ec != ssl::error::stream_truncated &&
-            http::error::end_of_stream)
-        throw boost::system::system_error{ec};
+    if (ec && ec != boost::system::errc::not_connected) throw boost::system::system_error{ec};
   } catch (const std::exception& ex) {
     LOG(ERROR) << ex.what();
     return {};


### PR DESCRIPTION
Reverts coinwalletdev/TangleScope#1 (wrong branch hmm)